### PR TITLE
Remove call to deprecated `np.int`

### DIFF
--- a/eBoruta/algorithm.py
+++ b/eBoruta/algorithm.py
@@ -404,7 +404,7 @@ class eBoruta(BaseEstimator, TransformerMixin):
                 f"Calculated {self.percentile}-percentile threshold: {threshold}"
             )
 
-            hits = (real_imp > threshold).astype(np.int)
+            hits = (real_imp > threshold).astype(int)
             hits_total = hits.sum()
             LOGGER.info(
                 f"{round(hits_total / len(hits) * 100, 2)}% ({hits_total}) "


### PR DESCRIPTION
In numpy 1.20.0, the `np.int` alias was deprecated. It seems that every published Boruta package suffers from this issue.

Numpy changelog: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations