### PR TITLE
feat: blackbox Pipeline support using PermutationExplainer

### DIFF
--- a/eBoruta/algorithm.py
+++ b/eBoruta/algorithm.py
@@ -361,6 +361,8 @@ class eBoruta(BaseEstimator, TransformerMixin):
         :param model_init_kwargs: Optional keyword arguments to initialize the
             estimator type with. If not provided, it is assumed that the
             estimator can be initialized without any arguments.
+            If model_type is a Pipeline, the last step must be a supported 
+            classifier or regressor named ``model``.
         :param kwargs: Passed to ``model.fit()`` method.
         :return: :class:`eBoruta` object.
         """

--- a/eBoruta/algorithm.py
+++ b/eBoruta/algorithm.py
@@ -172,6 +172,7 @@ class eBoruta(BaseEstimator, TransformerMixin):
                 if self.shap_gpu_tree:
                     explainer = shap.GPUTreeExplainer(model)
                 elif isinstance(model, Pipeline):
+                    # Treat pipeline as a black box model
                     explainer = shap.PermutationExplainer(model.predict, trial_data.x_train)
                 else:
                     explainer = shap.Explainer(model, trial_data.x_train)

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -12,6 +12,8 @@ from sklearn.ensemble import (
 )
 from sklearn.linear_model import RidgeClassifier, LogisticRegression
 from sklearn.svm import LinearSVC, LinearSVR
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
 from xgboost import XGBClassifier, XGBRegressor
 
 from eBoruta import eBoruta
@@ -21,13 +23,13 @@ from eBoruta.utils import sample_dataset
 def get_tree_models():
     # two-element tuples: (1) is regressor (2) model
     return [
-        (False, RandomForestClassifier),
-        (True, RandomForestRegressor),
-        (False, ExtraTreesClassifier),
-        (False, XGBClassifier),
-        (True, XGBRegressor),
-        (False, HistGradientBoostingClassifier),
-        (True, HistGradientBoostingRegressor),
+        (False, RandomForestClassifier, None),
+        (True, RandomForestRegressor, None),
+        (False, ExtraTreesClassifier, None),
+        (False, XGBClassifier, None),
+        (True, XGBRegressor, None),
+        (False, HistGradientBoostingClassifier, None),
+        (True, HistGradientBoostingRegressor, None),
         # (False, CatBoostClassifier),
         # (True, CatBoostRegressor),
     ]
@@ -36,10 +38,11 @@ def get_tree_models():
 def get_non_tree_models():
     return [
         # (True, AdaBoostRegressor),
-        (False, RidgeClassifier),
-        (False, LogisticRegression),
-        (False, LinearSVC),
-        (True, LinearSVR),
+        (False, RidgeClassifier, None),
+        (False, LogisticRegression, None),
+        (False, LinearSVC, None),
+        (True, LinearSVR, None),
+        (False, Pipeline, {"steps": [("pre", StandardScaler()), ("model", LinearSVC(C=1.0, class_weight="balanced"))]})
     ]
 
 
@@ -70,13 +73,13 @@ def test_models(
     n_features,
     n_informative,
 ):
-    is_reg, model = model
+    is_reg, model, model_init_kwargs = model
     x, y = make_dataset(
         is_reg, n_features=n_features, n_samples=n_samples, n_informative=n_informative
     )
     w = np.ones(len(y), dtype=float) if use_weights else None
     boruta = eBoruta()
-    boruta.fit(x, y, w, model_type=model)
+    boruta.fit(x, y, w, model_type=model, model_init_kwargs=model_init_kwargs)
     features = boruta.features_
     exp_tentative = x.shape[1] - len(features.accepted) - len(features.rejected)
     assert exp_tentative == len(features.tentative)
@@ -95,13 +98,13 @@ def test_non_tree_models(
     n_features,
     n_informative,
 ):
-    is_reg, model = model
+    is_reg, model, model_init_kwargs = model
     x, y = make_dataset(
         is_reg, n_features=n_features, n_samples=n_samples, n_informative=n_informative
     )
     w = np.ones(len(y), dtype=float) if use_weights else None
     boruta = eBoruta()
-    boruta.fit(x, y, w, model_type=model)
+    boruta.fit(x, y, w, model_type=model, model_init_kwargs=model_init_kwargs)
     features = boruta.features_
     exp_tentative = x.shape[1] - len(features.accepted) - len(features.rejected)
     assert exp_tentative == len(features.tentative)

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -6,8 +6,6 @@ from sklearn.ensemble import (
     RandomForestClassifier,
     RandomForestRegressor,
     ExtraTreesClassifier,
-    HistGradientBoostingClassifier,
-    HistGradientBoostingRegressor,
     # AdaBoostRegressor,
 )
 from sklearn.linear_model import RidgeClassifier, LogisticRegression
@@ -28,8 +26,6 @@ def get_tree_models():
         (False, ExtraTreesClassifier, None),
         (False, XGBClassifier, None),
         (True, XGBRegressor, None),
-        (False, HistGradientBoostingClassifier, None),
-        (True, HistGradientBoostingRegressor, None),
         # (False, CatBoostClassifier),
         # (True, CatBoostRegressor),
     ]

--- a/tests/test_algorithm.py
+++ b/tests/test_algorithm.py
@@ -11,7 +11,7 @@ from sklearn.ensemble import (
 from sklearn.linear_model import RidgeClassifier, LogisticRegression
 from sklearn.svm import LinearSVC, LinearSVR
 from sklearn.pipeline import Pipeline
-from sklearn.preprocessing import StandardScaler
+from sklearn.kernel_approximation import Nystroem
 from xgboost import XGBClassifier, XGBRegressor
 
 from eBoruta import eBoruta
@@ -38,7 +38,7 @@ def get_non_tree_models():
         (False, LogisticRegression, None),
         (False, LinearSVC, None),
         (True, LinearSVR, None),
-        (False, Pipeline, {"steps": [("pre", StandardScaler()), ("model", LinearSVC(C=1.0, class_weight="balanced"))]})
+        (False, Pipeline, {"steps": [("pre", Nystroem(kernel="rbf")), ("model", LinearSVC(C=1.0, class_weight="balanced"))]})
     ]
 
 


### PR DESCRIPTION
Introducing generic multi-step pipeline support using `shap.PermutationExplainer`.

Black box analysis is typically much less efficient than using trees or other model-aware explainers supported by `shap`.
